### PR TITLE
Add Missing Comma in posttest.json

### DIFF
--- a/experiment/posttest.json
+++ b/experiment/posttest.json
@@ -60,7 +60,7 @@
       },
       "correctAnswer": "d",
       "difficulty": "advanced"
-    }
+    },
     {
       "question": "Consider the following graph. A -> B (cost 1), A -> C (cost 2), B -> D (cost 3), C -> D (cost 1). What is the path that UCS will return?",
       "answers": {


### PR DESCRIPTION
This PR addresses a minor issue in the posttest.json file where a comma was missing before the last question. As the file is under review by an external reviewer, it's crucial to ensure no delays in the review process. The necessary change has been made to maintain the timeline and accuracy of the review.